### PR TITLE
Fixed MW 1.29 compatibility

### DIFF
--- a/includes/CreateUserPageHooks.php
+++ b/includes/CreateUserPageHooks.php
@@ -28,8 +28,8 @@ class CreateUserPageHooks {
 		$title = Title::newFromText( 'User:' . $user->mName );
 		if ( !is_null( $title ) && !$title->exists() ) {
 			$page = new WikiPage( $title );
-			$page->doEdit( $GLOBALS['wgCreateUserPage_PageContent'],
-				'create user page', EDIT_NEW);
+			$pageContent = new TextContent( $GLOBALS['wgCreateUserPage_PageContent'] );
+			$page->doEditContent( $pageContent, 'create user page', EDIT_NEW);
 		}
 		return true;
 	}


### PR DESCRIPTION
Replaced call to WikiPage::doEdit(),which was removed in 1.29, with a call to WikiPage::doEditContent().

This should retain backwards compatibility to 1.27 since WikiPage::doEditContent() exists in 1.27 and 1.28 but this has not been tested.